### PR TITLE
Add `ContentMeta` GET by-coords operation

### DIFF
--- a/backend/src/content-meta/content-meta.controller.ts
+++ b/backend/src/content-meta/content-meta.controller.ts
@@ -7,12 +7,14 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { ContentMetaService } from './content-meta.service';
 import {
   ContentMetaDTO,
   CreateContentMetaDTO,
+  FindByCoordsDTO,
   UpdateContentMetaDTO,
 } from './dtos';
 
@@ -36,6 +38,15 @@ export class ContentMetaController {
     return this.contentMetaService.findAll();
   }
 
+  @Get('by-coords')
+  @ApiOperation({ operationId: 'by-coords' })
+  @ApiOkResponse({ type: [ContentMetaDTO] })
+  public findByCoords(
+    @Query() coords: FindByCoordsDTO,
+  ): Promise<ContentMetaDTO[]> {
+    return this.contentMetaService.findByCoords(coords.lat, coords.lon);
+  }
+
   @Get(':id')
   @ApiOperation({ operationId: 'retrieve' })
   @ApiOkResponse({ type: ContentMetaDTO })
@@ -44,6 +55,7 @@ export class ContentMetaController {
   ): Promise<ContentMetaDTO | null> {
     return this.contentMetaService.findOne(id);
   }
+
   @Patch(':id')
   @ApiOperation({ operationId: 'update' })
   @ApiOkResponse({ type: ContentMetaDTO })

--- a/backend/src/content-meta/content-meta.service.ts
+++ b/backend/src/content-meta/content-meta.service.ts
@@ -45,6 +45,31 @@ export class ContentMetaService {
     });
   }
 
+  public async findByCoords(
+    latitude: number,
+    longitude: number,
+  ): Promise<ContentMeta[] | null> {
+    const foundFence = await this.geofenceRepository
+      .createQueryBuilder('fence')
+      .where(
+        'ST_Covers(fence.geometry, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326))',
+        {
+          longitude,
+          latitude,
+        },
+      )
+      .getOne();
+
+    if (foundFence === null) {
+      throw new NotFoundException(`No fence found for given coordinates`);
+    }
+
+    return this.contentMetaRepository.find({
+      where: { fence: { id: foundFence.id } },
+      relations: ['fence'],
+    });
+  }
+
   async update(
     id: string,
     updateContentMetaDto: UpdateContentMetaDTO,

--- a/backend/src/content-meta/dtos/find-by-coords.dto.ts
+++ b/backend/src/content-meta/dtos/find-by-coords.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber, Max, Min } from 'class-validator';
+
+export class FindByCoordsDTO {
+  @ApiProperty({ description: 'Latitude (-90 to 90)' })
+  @IsNotEmpty()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat: number;
+
+  @ApiProperty({ description: 'Longitude (-180 to 180)' })
+  @IsNotEmpty()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lon: number;
+}

--- a/backend/src/content-meta/dtos/index.ts
+++ b/backend/src/content-meta/dtos/index.ts
@@ -1,3 +1,4 @@
 export * from './create-content-meta.dto';
 export * from './content-meta.dto';
+export * from './find-by-coords.dto';
 export * from './update-content-meta.dto';


### PR DESCRIPTION
Fix #6

This pull request adds a new feature to the content meta API, allowing clients to retrieve content metadata by providing geographic coordinates (latitude and longitude). The main changes include introducing a new DTO for coordinate validation, updating the controller and service to support the new endpoint, and exposing the new route in the API.

**New endpoint for querying content meta by coordinates:**

* Added a new GET endpoint `by-coords` to `ContentMetaController`, allowing clients to query content metadata based on latitude and longitude. The endpoint uses the new `FindByCoordsDTO` for input validation and returns all ContentMeta within the geofence that covers the provided coordinates.

* Implemented the `findByCoords` method in `ContentMetaService`, which looks up the geofence containing the given coordinates and returns the associated content meta. Throws a `NotFoundException` if no geofence is found. (Using `ST_Covers` instead of `ST_Contains` as specified in the [docs](https://postgis.net/docs/ST_Covers.html))

**DTO and validation improvements:**

* Created a new DTO `FindByCoordsDTO` with validation rules for latitude and longitude, ensuring input is within valid geographic ranges.
* Exported `FindByCoordsDTO` from the DTO index for use in other modules.