### PR TITLE
Add repoUrl redirection

### DIFF
--- a/backend/src/content-meta/content-meta.controller.ts
+++ b/backend/src/content-meta/content-meta.controller.ts
@@ -3,11 +3,13 @@ import {
   Controller,
   Delete,
   Get,
+  HttpRedirectResponse,
   Param,
   ParseUUIDPipe,
   Patch,
   Post,
   Query,
+  Redirect,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { ContentMetaService } from './content-meta.service';
@@ -56,10 +58,22 @@ export class ContentMetaController {
     return this.contentMetaService.findOne(id);
   }
 
+  @Get('content/:id')
+  @ApiOperation({ operationId: 'download' })
+  @ApiOkResponse({ type: null })
+  @Redirect()
+  public async getRepoUrl(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<HttpRedirectResponse> {
+    const repoUrl = await this.contentMetaService.getRepoUrl(id);
+
+    return { url: repoUrl, statusCode: 302 };
+  }
+
   @Patch(':id')
   @ApiOperation({ operationId: 'update' })
   @ApiOkResponse({ type: ContentMetaDTO })
-  async update(
+  public async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateContentMetaDTO: UpdateContentMetaDTO,
   ): Promise<ContentMetaDTO> {

--- a/backend/src/content-meta/content-meta.service.ts
+++ b/backend/src/content-meta/content-meta.service.ts
@@ -45,6 +45,20 @@ export class ContentMetaService {
     });
   }
 
+  public async getRepoUrl(id: string): Promise<string | null> {
+    const url = (
+      await this.contentMetaRepository.findOne({
+        where: { id },
+        select: { id: true, repoUrl: true },
+      })
+    ).repoUrl;
+
+    if (!url)
+      throw new NotFoundException(`ContentMeta with ID ${id} not found`);
+
+    return url;
+  }
+
   public async findByCoords(
     latitude: number,
     longitude: number,


### PR DESCRIPTION
Fix #5 

This pull request introduces a new endpoint to the `ContentMetaController` that allows to retrieve and redirect to a repository URL associated with a specific content meta entry. It also adds the necessary service method to fetch the repository URL and improves error handling if the content meta entry is not found.

**New endpoint for repository URL redirection:**

* Added a `GET /content/:id` endpoint in `ContentMetaController` that redirects to the repository URL for the specified content meta entry, returning a 302 redirect response.
* Imported `HttpRedirectResponse` and `Redirect` from `@nestjs/common` to support the new redirect functionality in the controller.

**Service layer enhancements:**

* Implemented `getRepoUrl` method in `ContentMetaService` to retrieve the repository URL for a given content meta ID, throwing a `NotFoundException` if the entry does not exist.